### PR TITLE
Update fileFeed.go to comply with unfinished files from nfsen/profile…

### DIFF
--- a/fileFeed.go
+++ b/fileFeed.go
@@ -115,9 +115,9 @@ func setupFileFeeder(scanDirs []string, bucket string, twin int, influxDB *influ
 	fileCnt := 0
 	for file := range fileChannel {
 		fmt.Printf("file path: %s Time: %v\r", file.fileName, file.timeSlot)
-		if err := nfFile.Open(file.fileName); err != nil {
-			panic(err)
-		}
+		//if err := nfFile.Open(file.fileName); err != nil {
+		//	panic(err)
+		//}
 		// nfFile.String()
 		stat := nfFile.Stat()
 		calculateRate(&stat, uint64(twin))


### PR DESCRIPTION
…-data files

This is a nice to have, but interrupts the execution when trying to read unfinished files from nfsen profile-data folder. Without this seems to be working perfect. Maybe it should do a warning instead?